### PR TITLE
Removed route prefix, as the $module['url'] is appended automatically.

### DIFF
--- a/org.zikula.modulestudio.generator/src/org/zikula/modulestudio/generator/cartridges/zclassic/controller/additions/Routing.xtend
+++ b/org.zikula.modulestudio.generator/src/org/zikula/modulestudio/generator/cartridges/zclassic/controller/additions/Routing.xtend
@@ -36,8 +36,6 @@ class Routing {
         «appName.toLowerCase»:
             # define routing support for these controllers
             resource: "@«appName»/Controller"
-            # set a unique prefix to avoid route conflicts with other applications
-            prefix:   /«vendor.toLowerCase»«name.toLowerCase»
             # enable support for defining routes by annotations
             type:     annotation
     '''


### PR DESCRIPTION
See https://github.com/cmfcmf/core/blob/routing-2/src/docs/en/dev/UPGRADE-1.4.0.md#routing (updated documentation which will be merged in when the Routing PR is merged).
Advantage: The url prefix is already configurable via the Extensions webinterface.
